### PR TITLE
Add documentation regarding transparency of frame

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/anchored_artists.py
+++ b/lib/mpl_toolkits/axes_grid1/anchored_artists.py
@@ -53,6 +53,7 @@ class AnchoredDrawingArea(AnchoredOffsetbox):
 
         frameon : bool, default: True
             If True, draw a box around this artists.
+            If False, possibly allow image with proper transparency.
 
         **kwargs
             Keyworded arguments to pass to


### PR DESCRIPTION
Fixes #17018

## PR Summary
Since adding frameon=False to the AnnotationBbox leaves you with just the image with the proper transparency.
Thus adding a line of documentation might help the next people with similar problems.